### PR TITLE
Update arrayeditor.py to correct deprecated numpy operator

### DIFF
--- a/spyder/widgets/variableexplorer/arrayeditor.py
+++ b/spyder/widgets/variableexplorer/arrayeditor.py
@@ -266,7 +266,7 @@ class ArrayModel(QAbstractTableModel):
         elif role == Qt.BackgroundColorRole and self.bgcolor_enabled \
           and value is not np.ma.masked:
             hue = self.hue0+\
-                  self.dhue*(self.vmax-self.color_func(value)) \
+                  self.dhue*(np.logical_xor(self.vmax,self.color_func(value))) \
                   /(self.vmax-self.vmin)
             hue = float(np.abs(hue))
             color = QColor.fromHsvF(hue, self.sat, self.val, self.alp)


### PR DESCRIPTION
Changed numpy boolean subract operator '-' to np.logical_xor. As suggested in the numpy deprec warning.
Tested locally with no error originally described in #4663

